### PR TITLE
fix: `SerializeOptions` type export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/mdx",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "Markdown parser from Mintlify",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkSmartypants from "remark-smartypants";
 import { rehypeSyntaxHighlighting } from "../plugins/index.js";
-import { SerializeOptions } from "../types/index.js";
+import type { SerializeOptions } from "../types/index.js";
 
 export const getCompiledMdx = async ({
   source,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,3 @@
-import type { SerializeOptions } from "next-mdx-remote/dist/types";
 import { compileMDX } from "next-mdx-remote/rsc";
 import type { CompileMDXResult, MDXRemoteProps } from "next-mdx-remote/rsc";
 import { serialize } from "next-mdx-remote/serialize";
@@ -7,6 +6,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkSmartypants from "remark-smartypants";
 import { rehypeSyntaxHighlighting } from "../plugins/index.js";
+import { SerializeOptions } from "../types/index.js";
 
 export const getCompiledMdx = async ({
   source,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,6 @@
 import type { MDXRemoteSerializeResult } from 'next-mdx-remote';
-import type { SerializeOptions } from 'next-mdx-remote/dist/types';
+import type { serialize } from 'next-mdx-remote/serialize';
 
-export { MDXRemoteSerializeResult as MDXCompiledResult, SerializeOptions };
+type SerializeOptions = NonNullable<Parameters<typeof serialize>[1]>;
+
+export type { MDXRemoteSerializeResult as MDXCompiledResult, SerializeOptions };


### PR DESCRIPTION
`SerializeOptions` is not accessible from outside of this package because it is illegally imported from `next-mdx-remote/dist/types`. This updates the export to "legally" import the `serialize` function and extract the `SerializeOptions` type that way