### PR TITLE
fix: remove dir import

### DIFF
--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/mdx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Markdown parser from Mintlify",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mdx/src/client/rsc.tsx
+++ b/packages/mdx/src/client/rsc.tsx
@@ -5,7 +5,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import remarkSmartypants from 'remark-smartypants';
 
-import { rehypeSyntaxHighlighting } from '../plugins';
+import { rehypeSyntaxHighlighting } from '../plugins/index.js';
 
 export async function MDXRemote({
   source,

--- a/packages/mdx/tsconfig.json
+++ b/packages/mdx/tsconfig.json
@@ -6,9 +6,7 @@
     "target": "ES2021",
     "outDir": "dist",
     "declaration": true,
-    "moduleResolution": "node",
-    "module": "esnext",
-    "allowJs": true
+    "module": "Node16"
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Got this fun error when trying to use this package:

```
⨯ Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/[...]/node_modules/@mintlify/mdx/dist/plugins' is not supported resolving ES modules imported from /[...]/node_modules/@mintlify/mdx/dist/client/rsc.js
```

Also updated module setting to avoid this in the future